### PR TITLE
I've added a Flask web UI for PDF to Markdown conversion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - 使用 Gemini 2.5 Flash OCR API 从图像中提取文本
 - 将提取的文本转换为结构化的 Markdown
 - 简单的命令行界面
+- 基于 Web 的用户界面
 
 ## 系统要求
 
@@ -43,6 +44,28 @@ python -m pdf2md.cli --input 输入文件.pdf --output 输出文件.md
 - `--output`：输出 Markdown 文件的路径（可选，默认为输入文件名加 .md 扩展名）
 - `--dpi`：图像转换的 DPI（可选，默认：300）
 - `--format`：转换的图像格式（可选，默认：png）
+
+## Web 应用使用方法
+
+本项目还包含一个基于 Web 的 PDF 转 Markdown 用户界面。
+
+1.  **确保所有依赖都已安装：**
+    ```bash
+    pip install -r requirements.txt
+    ```
+    (如果您尚未安装 Poppler 或设置 Gemini API 密钥，请参照上述主要安装说明进行操作。)
+
+2.  **运行 Flask 应用：**
+    ```bash
+    python app.py
+    ```
+    应用通常会在您的网络浏览器中的 `http://127.0.0.1:5000/` 地址可用。
+
+3.  **使用 Web UI：**
+    - 在浏览器中打开该 URL。
+    - 点击“选择文件”按钮选择一个 PDF 文件。
+    - 点击“上传并转换”。
+    - 转换后的 Markdown 文本将显示在结果页面上。
 
 ## 开发路线图
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,77 @@
+import os
+import tempfile
+from pathlib import Path
+from flask import Flask, render_template, request, redirect, url_for
+from werkzeug.utils import secure_filename
+from pdf2md.pdf_processor import PDFProcessor
+from pdf2md.ocr_processor import OCRProcessor
+from pdf2md.markdown_generator import MarkdownGenerator
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'supersecretkey'
+
+UPLOAD_FOLDER = 'uploads'
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
+ALLOWED_EXTENSIONS = {'pdf'}
+def allowed_file(filename):
+    return '.' in filename and \
+           filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        # No file part
+        return redirect(request.url)
+    file = request.files['file']
+    if file.filename == '':
+        # No selected file
+        return redirect(request.url)
+    if file and allowed_file(file.filename):
+        filename = secure_filename(file.filename)
+        filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        file.save(filepath)
+
+        markdown_content = process_pdf_to_markdown(filepath)
+        # Clean up the uploaded file after processing
+        # os.remove(filepath) # Consider if you want to keep or remove the uploaded PDF
+        return render_template('result.html', markdown_content=markdown_content, filename=filename)
+    else:
+        # Invalid file type
+        return "Invalid file type. Please upload a PDF."
+
+def process_pdf_to_markdown(pdf_filepath):
+    try:
+        # Create a temporary directory for intermediate files
+        with tempfile.TemporaryDirectory(prefix="pdf2md_webapp_") as temp_dir:
+            # Step 1: Convert PDF to images
+            # Assuming default DPI and format for now, can be made configurable later
+            pdf_processor = PDFProcessor(dpi=300, image_format='png')
+            image_paths = pdf_processor.convert_pdf_to_images(pdf_filepath, temp_dir)
+            if not image_paths:
+                return "Error: Could not convert PDF to images."
+
+            # Step 2: Process images with OCR
+            # API key should be configured via .env file (OCRProcessor handles this)
+            ocr_processor = OCRProcessor()
+            ocr_results = ocr_processor.process_images(image_paths)
+            if not ocr_results:
+                return "Error: OCR processing failed."
+
+            # Step 3: Generate Markdown
+            markdown_generator = MarkdownGenerator()
+            markdown_text = markdown_generator.generate_markdown(ocr_results)
+
+            return markdown_text
+    except Exception as e:
+        # Log the exception e for debugging
+        print(f"Error during PDF processing: {e}")
+        return f"An error occurred during processing: {str(e)}"
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ google-generativeai==0.3.2
 python-dotenv==1.0.0
 argparse==1.4.0
 tqdm==4.66.1
+Flask

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>PDF to Markdown Converter</title>
+    <style>
+      body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+      .container { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+      h1 { color: #333; }
+      input[type="file"] { margin-bottom: 10px; }
+      input[type="submit"] { padding: 10px 15px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; }
+      input[type="submit"]:hover { background-color: #0056b3; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>PDF to Markdown Converter</h1>
+      <form method="post" action="{{ url_for('upload_file') }}" enctype="multipart/form-data">
+        <p><input type="file" name="file" accept=".pdf"></p>
+        <p><input type="submit" value="Upload and Convert"></p>
+      </form>
+    </div>
+  </body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Conversion Result - {{ filename }}</title>
+    <style>
+      body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+      .container { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+      h1 { color: #333; }
+      pre { background-color: #eee; padding: 15px; border-radius: 4px; white-space: pre-wrap; word-wrap: break-word; }
+      a { color: #007bff; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Conversion Result for {{ filename }}</h1>
+      <h2>Markdown Output:</h2>
+      <pre>{{ markdown_content }}</pre>
+      <p><a href="{{ url_for('index') }}">Convert another file</a></p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This commit introduces a web-based user interface for the PDF to Markdown converter. You can now upload PDF files through a web browser and receive the converted Markdown text.

Key changes:
- Added Flask as a dependency.
- Created `app.py` to serve the web application.
  - Implemented routes for file upload and result display.
  - Integrated the existing PDF processing logic (`PDFProcessor`, `OCRProcessor`, `MarkdownGenerator`) into the web app.
- Created HTML templates (`index.html`, `result.html`) for the UI.
- Updated `README.md` with instructions on how to run the web application and added the web UI to the list of features.